### PR TITLE
advance allot with slot len sort

### DIFF
--- a/slots_test.go
+++ b/slots_test.go
@@ -10,37 +10,61 @@ type Slot = int
 type Inst = string
 
 func TestAllotUnion(t *testing.T) {
-	first := Allot(nil, []Slot{1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5}, []Inst{"a", "b"}, nil)
-	t.Log(first)
+	t.Run("case 1", func(t *testing.T) {
+		first := Allot(nil, []Slot{1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5}, []Inst{"a", "b"}, nil)
+		t.Log(first)
 
-	second := Allot(first, nil, []Inst{"c", "d", "e"}, nil)
-	t.Log(second)
+		second := Allot(first, nil, []Inst{"c", "d", "e"}, nil)
+		t.Log(second)
 
-	third := Allot(second, nil, nil, []Inst{"b", "e", "f"})
-	t.Log(third)
+		third := Allot(second, nil, nil, []Inst{"b", "e", "f"})
+		t.Log(third)
 
-	fourth := Allot(third, []Slot{1, 2, 3, 4, 5}, nil, nil)
-	t.Log(fourth)
+		fourth := Allot(third, []Slot{1, 2, 3, 4, 5}, nil, nil)
+		t.Log(fourth)
 
-	fifth := Allot(fourth, nil, []Inst{"g"}, []Inst{"d"})
-	t.Log(fifth)
+		fifth := Allot(fourth, nil, []Inst{"g"}, []Inst{"d"})
+		t.Log(fifth)
 
-	sixth := Allot(fifth, []Slot{4, 3, 2, 5, 1}, []Inst{"h", "i"}, nil)
-	t.Log(sixth)
+		sixth := Allot(fifth, []Slot{4, 3, 2, 5, 1}, []Inst{"h", "i"}, nil)
+		t.Log(sixth)
 
-	unionth := Union(fifth, sixth)
-	t.Log(unionth)
+		unionth := Union(fifth, sixth)
+		t.Log(unionth)
 
-	final := Reverse(unionth)
-	t.Log(final)
+		final := Reverse(unionth)
+		t.Log(final)
 
-	replicas := 0
-	for _, insts := range final {
-		if replicas == 0 {
-			replicas = len(insts)
+		replicas := 0
+		for _, insts := range final {
+			if replicas == 0 {
+				replicas = len(insts)
+			}
+			if len(insts) != replicas {
+				t.Fail()
+			}
 		}
-		if len(insts) != replicas {
-			t.Fail()
-		}
-	}
+	})
+
+	t.Run("case 2", func(t *testing.T) {
+		first := Allot(nil, []Slot{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, []Inst{"a", "b", "c"}, nil)
+		t.Log(first)
+
+		second := Allot(first, nil, []Inst{"d"}, nil)
+		t.Log(second)
+
+		third := Allot(second, nil, []Inst{"e", "f", "g"}, []Inst{"a"})
+		t.Log(third)
+	})
+
+	t.Run("case 3", func(t *testing.T) {
+		first := Allot(nil, []Slot{1, 2, 3, 4, 5, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 5, 5, 5}, []Inst{"a", "b", "c"}, nil)
+		t.Log(first)
+
+		second := Allot(first, nil, []Inst{"d"}, nil)
+		t.Log(second)
+
+		third := Allot(second, nil, []Inst{"e", "f", "g"}, []Inst{"a"})
+		t.Log(third)
+	})
 }


### PR DESCRIPTION
reallocate the slot with a higher priority from the instant with longer slots

Unbalanced:
![78fca805-3856-4e50-b113-f17b44771510](https://github.com/user-attachments/assets/48100c4a-01c2-41f9-9f6c-e360d79cc7fc)